### PR TITLE
Optional QR Code for Article URI

### DIFF
--- a/MMM-NewsAPI.css
+++ b/MMM-NewsAPI.css
@@ -92,5 +92,6 @@
   }
 
   #NEWSAPI .article #NEWSAPI_QRCODE {
-    float: left;
+    float: right;
+    margin-left: 20px;
   }

--- a/MMM-NewsAPI.css
+++ b/MMM-NewsAPI.css
@@ -90,4 +90,8 @@
   #NEWSAPI.vertical #NEWSAPI_CONTENT {
     padding-bottom:5px;
   }
-  
+
+  #NEWSAPI .article #NEWSAPI_QRCODE {
+    float: left;
+    margin-right: 30px;
+  }

--- a/MMM-NewsAPI.css
+++ b/MMM-NewsAPI.css
@@ -93,5 +93,4 @@
 
   #NEWSAPI .article #NEWSAPI_QRCODE {
     float: left;
-    margin-right: 30px;
   }

--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -28,6 +28,11 @@ Module.register("MMM-NewsAPI", {
     getStyles: function() {
         return [this.file("MMM-NewsAPI.css")]
     },
+    
+    // Import QR code script file
+    getScripts: function() {
+        return ["https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js"];
+    },
 
     // Start process
     start: function() {
@@ -169,7 +174,12 @@ Module.register("MMM-NewsAPI", {
             news.classList.remove("hideArticle")
             news.classList.add("showArticle")
             newsContent.innerHTML = template
-
+            if (this.config.qrCode) {
+                var qr = new QRious({
+                    element: document.getElementById('NEWSAPI_QRCODE'),
+                    value: article.url
+                });
+            }
         }, 900)
         this.timer = setTimeout(() => {
             this.index++

--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -12,6 +12,7 @@ Module.register("MMM-NewsAPI", {
         drawInterval: 1000*30,
         fetchInterval: 1000*60*60,
         debug: false,
+        qrCode: false,
         query: {
             country: "us",
             category: "",

--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -35,6 +35,7 @@ Module.register("MMM-NewsAPI", {
         this.index = 0
         this.timer = null
         this.template = ""
+        suspended = false;
         this.newsArticles = []
         if (this.config.debug) Log.log("config: ", JSON.stringify(this.config))
         // Start function call to node_helper
@@ -50,13 +51,13 @@ Module.register("MMM-NewsAPI", {
       resume: function () {
         Log.info('Resuming module ' + this.name);
         Log.debug('with config: ' + JSON.stringify(this.config));
-        this.suspend = false;
+        this.suspended = false;
         this.updateDom()
       },
     
       suspend: function () {
         Log.info('Suspending module ' + this.name);
-        this.suspend = true;
+        this.suspended = true;
       },
 
     getDom: function() {

--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -110,7 +110,7 @@ Module.register("MMM-NewsAPI", {
     socketNotificationReceived: function(notification, payload) {
         if (this.config.debug) Log.log("payload received: ", JSON.stringify(payload))
         var self = this
-        if (notification === "UPDATE") {
+        if (notification === "NEWSAPI_UPDATE") {
             this.newsArticles = payload
             if (this.firstUpdate == 0) {
                 this.firstUpdate = 1

--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -12,7 +12,8 @@ Module.register("MMM-NewsAPI", {
         drawInterval: 1000*30,
         fetchInterval: 1000*60*60,
         debug: false,
-        qrCode: false,
+        QRCode: false,
+        QRPadding: 0,
         query: {
             country: "us",
             category: "",
@@ -175,10 +176,11 @@ Module.register("MMM-NewsAPI", {
             news.classList.remove("hideArticle")
             news.classList.add("showArticle")
             newsContent.innerHTML = template
-            if (this.config.qrCode) {
+            if (this.config.QRCode) {
                 var qr = new QRious({
                     element: document.getElementById('NEWSAPI_QRCODE'),
-                    value: article.url
+                    value: article.url,
+                    padding: this.config.QRPadding
                 });
             }
         }, 900)

--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -13,7 +13,6 @@ Module.register("MMM-NewsAPI", {
         fetchInterval: 1000*60*60,
         debug: false,
         QRCode: false,
-        QRPadding: 0,
         query: {
             country: "us",
             category: "",
@@ -179,8 +178,7 @@ Module.register("MMM-NewsAPI", {
             if (this.config.QRCode) {
                 var qr = new QRious({
                     element: document.getElementById('NEWSAPI_QRCODE'),
-                    value: article.url,
-                    padding: this.config.QRPadding
+                    value: article.url
                 });
             }
         }, 900)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you like my module you can support my work by giving me a star ir buy me a co
 - Replaced moment with luxon
 - Replaced request with node-fetch
 - Remove the following line from your config `className: "NEWS",`. It is no longer required and module will stop working if not removed.
-- Optional QR code via Qrious
+- Optional QR code via QRious
 
 ## Dependencies
 - luxon@2.0.2
@@ -63,7 +63,8 @@ The following properties can be configured:
 | `templateFile`               | The template file to use. You can create your own template file and reference here. For now use `template.html`
 | `fetchInterval`              | The time interval between fetching new articles. There is a daily limit of 100 calls per apiKey. Best to set this to 100*60*60 
 | `apiKey`                     | You can obtain an API Key from [NewsAPi.org](https://newsapi.org/)
-| `qrCode`                     | Boolean true/false value to display QR code for article URL. Default is false.
+| `QRCode`                     | Boolean true/false value to display QR code for article URL. Default is false.
+| `QRPadding`                  | Integer value for padding around QR Code. Default is 0.
 
 ## Query Options
 
@@ -99,7 +100,7 @@ When using `headlines`, `country` and `sources` cannot be used together. <br>The
                         drawInterval: 1000*30,
                         templateFile: "template.html",
                         fetchInterval: 1000*60*60,
-                        qrCode: true,
+                        QRCode: true,
                         query: {
                                 country: "",
                                 category: "",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ A [MagicMirror²](https://magicmirror.builders) module to to get news from [News
 
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](LICENSE)
 
+## Support
+If you like my module you can support my work by giving me a star ir buy me a coffee.
+
+<a href="https://www.buymeacoffee.com/mumblebaj" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Beer" style="height: 45px !important;width: 180px !important;" ></a>
+
 ![Example](screen1.PNG) 
 
 ## Updates

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The following properties can be configured:
 | `fetchInterval`              | The time interval between fetching new articles. There is a daily limit of 100 calls per apiKey. Best to set this to 100*60*60 
 | `apiKey`                     | You can obtain an API Key from [NewsAPi.org](https://newsapi.org/)
 | `QRCode`                     | Boolean true/false value to display QR code for article URL. Default is false.
-| `QRPadding`                  | Integer value for padding around QR Code. Default is 0.
 
 ## Query Options
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ A [MagicMirror²](https://magicmirror.builders) module to to get news from [News
 - Remove the following line from your config `className: "NEWS",`. It is no longer required and module will stop working if not removed.
 
 ## Dependencies
-- luxon 2.0.2
-- node-fetch 2.6.1
+- luxon@2.0.2
+- node-fetch@2.6.1
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ If you like my module you can support my work by giving me a star ir buy me a co
 - Replaced moment with luxon
 - Replaced request with node-fetch
 - Remove the following line from your config `className: "NEWS",`. It is no longer required and module will stop working if not removed.
+- Optional QR code via Qrious
 
 ## Dependencies
 - luxon@2.0.2
 - node-fetch@2.6.1
+- qrious@4.0.2
 
 ## Installation
 
@@ -61,6 +63,7 @@ The following properties can be configured:
 | `templateFile`               | The template file to use. You can create your own template file and reference here. For now use `template.html`
 | `fetchInterval`              | The time interval between fetching new articles. There is a daily limit of 100 calls per apiKey. Best to set this to 100*60*60 
 | `apiKey`                     | You can obtain an API Key from [NewsAPi.org](https://newsapi.org/)
+| `qrCode`                     | Boolean true/false value to display QR code for article URL. Default is false.
 
 ## Query Options
 
@@ -96,6 +99,7 @@ When using `headlines`, `country` and `sources` cannot be used together. <br>The
                         drawInterval: 1000*30,
                         templateFile: "template.html",
                         fetchInterval: 1000*60*60,
+                        qrCode: true,
                         query: {
                                 country: "",
                                 category: "",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A [MagicMirror²](https://magicmirror.builders) module to to get news from [News
 - Replaced request with node-fetch
 - Remove the following line from your config `className: "NEWS",`. It is no longer required and module will stop working if not removed.
 
+## Dependencies
+- luxon 2.0.2
+- node-fetch 2.6.1
+
 ## Installation
 
 In your terminal, go to your MagicMirror's Module folder:

--- a/headlines.html
+++ b/headlines.html
@@ -1,11 +1,7 @@
-<div class="article %CLASSNAME%" id="%ARTICLEID%">
+<div class="article %CLASSNAME%">
   <canvas id="NEWSAPI_QRCODE"></canvas>
   <div class="header">
     <div class="title">%TITLE%</div>
-  </div>
-  <div class="content">
-    %ARTICLEIMAGE%
-    %DESCRIPTION%
   </div>
   <div class="footer">
     <div class="author" id="%AUTHOR%">%AUTHOR% | </div>

--- a/node_helper.js
+++ b/node_helper.js
@@ -101,7 +101,8 @@ module.exports = NodeHelper.create({
         var count = payload.pageSize
         for (j in ret.articles) {
             var article = ret.articles[j]
-            article.sourceName = article.source.name
+            article.sourceName = article.source.Name
+            article.sourceId = article.source.Id
             // var time = moment(article.publishedAt)
             // article.publishedAt = time.fromNow()
             luxTime = DateTime.fromISO(article.publishedAt).toRelative()

--- a/node_helper.js
+++ b/node_helper.js
@@ -113,7 +113,7 @@ module.exports = NodeHelper.create({
         }
         if (results.length > 0) this.articles = this.articles.concat(results)
         if (payload.debug) console.log("sending articles: ", JSON.stringify(this.articles))
-        this.sendSocketNotification("UPDATE", this.articles)
+        this.sendSocketNotification("NEWSAPI_UPDATE", this.articles)
     },
 
     async getData(callScript, payload) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,59 +1,109 @@
 {
   "name": "mmm-newsapi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-newsapi",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "luxon": "^2.0.2",
         "node-fetch": "^2.6.1",
-        "xmlhttprequest": "^1.8.0"
+        "qrious": "^4.0.2"
       }
     },
     "node_modules/luxon": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.2.tgz",
-      "integrity": "sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
+      "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "engines": {
-        "node": ">=0.4.0"
+    "node_modules/qrious": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/qrious/-/qrious-4.0.2.tgz",
+      "integrity": "sha512-xWPJIrK1zu5Ypn898fBp8RHkT/9ibquV2Kv24S/JY9VYEhMBMKur1gHVsOiNUh7PHP9uCgejjpZUHUIXXKoU/g=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     }
   },
   "dependencies": {
     "luxon": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.2.tgz",
-      "integrity": "sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
+      "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A=="
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    "qrious": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/qrious/-/qrious-4.0.2.tgz",
+      "integrity": "sha512-xWPJIrK1zu5Ypn898fBp8RHkT/9ibquV2Kv24S/JY9VYEhMBMKur1gHVsOiNUh7PHP9uCgejjpZUHUIXXKoU/g=="
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/mumblebaj/MMM-NewsAPI#readme",
   "dependencies": {
     "luxon": "^2.0.2",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "qrious": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/mumblebaj/MMM-NewsAPI#readme",
   "dependencies": {
     "luxon": "^2.0.2",
-    "node-fetch": "^2.6.1",
-    "xmlhttprequest": "^1.8.0"
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
What it says on the tin, really. Have added QRious to provide a QR link to the article URL as an option. Default sticks the QR code over on the right, but I used a custom css on my end to shift it left. I went right for this because otherwise there's a big black empty space where the canvas object goes thanks to the margin I put on there. 

Also fixed a minor bug with article ID/Name not being populated. I think the output JSON from the newsapi no longer includes the description/content any more, so I also added a headline.html template that might be useful with less information in there.

Hopefully it's a useful addition, but if not, no worries - just thought it might be useful to someone else.