### PR TITLE
Add a default Fallback string when replacing tags for news articles.

### DIFF
--- a/MMM-NewsAPI.js
+++ b/MMM-NewsAPI.js
@@ -143,7 +143,7 @@ Module.register("MMM-NewsAPI", {
         for (i in tag) {
             var t = tag[i]
             var tu = "%" + t.toUpperCase() + "%"
-            template = template.replace(tu, article[t])
+            template = template.replace(tu, article[t] || '')
         }
 
         var imgtag = (article.urlToImage) ? `<img class="articleImage" src="` + article.urlToImage + `"/>` : ""


### PR DESCRIPTION
This small change adds a fallback string when replacing tags on new articles.
I was noticing that my "description" was outputting the string 'null' on my MagicMirror. This fixes that issue and falls back.